### PR TITLE
feat: Implement MaterialCard molecule and initial M3 setup

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@material/web": "^2.3.0",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
         "@testing-library/dom": "^10.4.0",
@@ -2919,6 +2920,28 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
+      "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "node_modules/@material/web": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-2.3.0.tgz",
+      "integrity": "sha512-r7ccZHthMk5tM05goPJ965hQ99ptMyZt7i8Xi8+RmEqK3ZXaMtjx+s4p+9OVX+vgOS3zpop+g1yGYXtOOlrwUg==",
+      "dependencies": {
+        "lit": "^2.8.0 || ^3.0.0",
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.1.0",
@@ -10754,6 +10777,34 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/lit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
+      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
+      "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@material/web": "^2.3.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@testing-library/dom": "^10.4.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,8 @@ import DashboardCard from './components/DashboardCard';
 import TiendasPage from './pages/TiendasPage';
 import UsuariosPage from './pages/UsuariosPage';
 import ClientesPage from './pages/ClientesPage';
+import MaterialCardTestPage from './pages/MaterialCardTestPage';
+import DashboardPage from './pages/DashboardPage';
 
 function App() {
   return (
@@ -24,6 +26,8 @@ function App() {
             <Route path="/tiendas" element={<TiendasPage />} />
             <Route path="/usuarios" element={<UsuariosPage />} />
             <Route path="/clientes" element={<ClientesPage />} />
+            <Route path="/test-material-card" element={<MaterialCardTestPage />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/" element={
               <Box sx={{ p: 3 }}>
                 <Typography variant="h4" component="h1" gutterBottom sx={{ mb: 3 }}>

--- a/frontend/src/__mocks__/@material/web/button/filled-button.js
+++ b/frontend/src/__mocks__/@material/web/button/filled-button.js
@@ -1,0 +1,8 @@
+// frontend/src/__mocks__/@material/web/button/filled-button.js
+import React from 'react';
+// eslint-disable-next-line react/display-name
+export default ({ children, onClick, ...props }) => (
+  <button data-testid="md-filled-button" onClick={onClick} {...props}>
+    {children}
+  </button>
+);

--- a/frontend/src/__mocks__/@material/web/elevated-card.js
+++ b/frontend/src/__mocks__/@material/web/elevated-card.js
@@ -1,0 +1,4 @@
+// frontend/src/__mocks__/@material/web/elevated-card.js
+import React from 'react';
+// eslint-disable-next-line react/display-name
+export default ({ children, ...props }) => <div data-testid="md-elevated-card" {...props}>{children}</div>;

--- a/frontend/src/molecules/MaterialCard.js
+++ b/frontend/src/molecules/MaterialCard.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// Imports moved to src/index.js
+
+const MaterialCard = ({ title, content, actionText, onActionClick }) => {
+  return (
+    <md-elevated-card>
+      <div style={{ padding: '16px' }}>
+        <h3>{title}</h3>
+        <p>{content}</p>
+        {actionText && onActionClick && (
+          <div style={{ marginTop: '16px', textAlign: 'right' }}>
+            <md-filled-button onClick={onActionClick}>
+              {actionText}
+            </md-filled-button>
+          </div>
+        )}
+      </div>
+    </md-elevated-card>
+  );
+};
+
+MaterialCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  actionText: PropTypes.string,
+  onActionClick: PropTypes.func,
+};
+
+export default MaterialCard;

--- a/frontend/src/molecules/MaterialCard.test.js
+++ b/frontend/src/molecules/MaterialCard.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MaterialCard from './MaterialCard';
+
+// Mock the custom elements for testing purposes as they might not be fully defined in a Jest/JSDOM environment
+// or might rely on browser APIs not present.
+// We are testing the React component's logic, not the custom elements themselves here.
+// jest.mock('@material/web/elevated-card.js', () => {}); // Using __mocks__ directory instead
+// jest.mock('@material/web/button/filled-button.js', () => {}); // Using __mocks__ directory instead
+
+describe('MaterialCard', () => {
+  const defaultProps = {
+    title: 'Test Title',
+    content: 'Test content for the card.',
+  };
+
+  test('renders title and content correctly', () => {
+    render(<MaterialCard {...defaultProps} />);
+    expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.content)).toBeInTheDocument();
+  });
+
+  test('renders action button when actionText is provided and calls onActionClick on click', () => {
+    const mockOnActionClick = jest.fn();
+    const actionText = 'Click Me';
+    render(
+      <MaterialCard
+        {...defaultProps}
+        actionText={actionText}
+        onActionClick={mockOnActionClick}
+      />
+    );
+
+    const actionButton = screen.getByText(actionText);
+    expect(actionButton).toBeInTheDocument();
+    // Note: Since we're not deeply rendering the custom element's own button structure,
+    // we'll assume the <md-filled-button> itself is clickable if present.
+    // For a more robust test of the custom element interaction, a browser environment (e.g. Playwright) would be needed.
+    // Here we check if the button text is present and the click handler is attached to the md-filled-button.
+
+    // Simulate click on the md-filled-button custom element
+    // We need to ensure the click handler is passed down.
+    // In a real custom element, the click might be on an inner button.
+    // For this test, we assume the onClick prop on <md-filled-button> works.
+    fireEvent.click(actionButton); // Or screen.getByRole('button', { name: actionText }) if role is set by md-filled-button
+    expect(mockOnActionClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not render action button when actionText is not provided', () => {
+    render(<MaterialCard {...defaultProps} />);
+    // Using queryByText because getByText would throw an error if not found, which is the desired state.
+    expect(screen.queryByText('Click Me')).not.toBeInTheDocument(); // Assuming 'Click Me' or any action text
+    // A more generic way if we don't know the actionText beforehand:
+    // Check if any element with role 'button' (typical for buttons) exists beyond what might be inherent in the card.
+    // However, md-filled-button is a custom element, its role might not be immediately 'button' to JSDOM.
+    // So, checking for absence of any passed actionText is safer.
+    const buttons = screen.queryAllByRole('button'); // This might be fragile depending on md-filled-button's internals
+    // A better check might be to ensure no div wrapping the button is rendered, or check for a specific test-id if we added one.
+    // For now, we'll rely on the fact that if actionText is not there, the button text won't be.
+  });
+
+  test('does not render action button when onActionClick is not provided, even if actionText is', () => {
+    const actionText = 'Click Me';
+    render(<MaterialCard {...defaultProps} actionText={actionText} />);
+    expect(screen.queryByText(actionText)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import MaterialCard from '../molecules/MaterialCard';
+import { Box, Typography, Grid } from '@mui/material';
+
+const DashboardPage = () => {
+  const handleCardAction = () => {
+    alert('Dashboard card action clicked!');
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Dashboard Overview
+      </Typography>
+
+      <Grid container spacing={3} sx={{ mt: 2 }}>
+        <Grid item xs={12} sm={6} md={4}>
+          <MaterialCard
+            title="Feature Update"
+            content="Check out the latest features and improvements we've rolled out this month."
+            actionText="Learn More"
+            onActionClick={handleCardAction}
+          />
+        </Grid>
+
+        <Grid item xs={12} sm={6} md={4}>
+          <MaterialCard
+            title="System Status"
+            content="All systems are currently operational and running smoothly."
+          />
+        </Grid>
+
+        <Grid item xs={12} sm={6} md={4}>
+          <MaterialCard
+            title="User Statistics"
+            content="Monthly active users are up by 15% compared to last month."
+            actionText="View Details"
+            onActionClick={() => alert('User stats details!')}
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/MaterialCardTestPage.js
+++ b/frontend/src/pages/MaterialCardTestPage.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import MaterialCard from '../molecules/MaterialCard';
+import { Box, Typography } from '@mui/material';
+
+const MaterialCardTestPage = () => {
+  const handleAction1 = () => {
+    alert('Action 1 clicked!');
+  };
+
+  const handleAction2 = () => {
+    alert('Action 2 clicked!');
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Material Card Test Page
+      </Typography>
+
+      <Typography variant="h6" component="h2" gutterBottom sx={{ mt: 3 }}>
+        Card with Action
+      </Typography>
+      <MaterialCard
+        title="Card with Action Button"
+        content="This card includes an action button. Clicking it should trigger an alert."
+        actionText="Click Me"
+        onActionClick={handleAction1}
+      />
+
+      <Typography variant="h6" component="h2" gutterBottom sx={{ mt: 5 }}>
+        Card without Action
+      </Typography>
+      <MaterialCard
+        title="Card without Action Button"
+        content="This card does not have an action button and should not display one."
+      />
+
+      <Typography variant="h6" component="h2" gutterBottom sx={{ mt: 5 }}>
+        Another Card with Action
+      </Typography>
+      <MaterialCard
+        title="Yet Another Card"
+        content="This is another example of a card with an action button."
+        actionText="Do Something Else"
+        onActionClick={handleAction2}
+      />
+    </Box>
+  );
+};
+
+export default MaterialCardTestPage;


### PR DESCRIPTION
This commit introduces the first Material Design 3 based molecule, `MaterialCard.js`.

Key changes:
- Added `@material/web` as a dependency.
- Created `MaterialCard.js` in `frontend/src/molecules/` utilizing `<md-elevated-card>` and `<md-filled-button>`. This card supports a title, content, and an optional action button.
- Imported Material Web Components (`@material/web/elevated-card.js`, `@material/web/button/filled-button.js`) globally in `frontend/src/index.js` to ensure proper registration of custom elements.
- Created `frontend/src/pages/DashboardPage.js` to demonstrate the usage of the new `MaterialCard` component.
- Added unit tests for `MaterialCard.js` in `frontend/src/molecules/MaterialCard.test.js`, including manual mocks for the Material Web Components to facilitate testing in JSDOM.

This work sets the foundation for further integration of Material Design 3 components and improving the UI/UX of the application.