### PR TITLE
feat: Initial migration from MUI to MWC and refactor core atoms

### DIFF
--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -1,90 +1,61 @@
-# ERP Visual Design Guidelines
+# ERP Visual Design Guidelines (Material Web Components Edition)
 
-This document outlines the core visual design principles and specifications for the ERP application frontend. Adhering to these guidelines will ensure a consistent and polished user experience.
+This document outlines the core visual design principles and specifications for the ERP application frontend, now based on **Material Web Components (MWC)**. Adhering to these guidelines will ensure a consistent and polished user experience.
 
-## 1. Color Palette
+## 1. Component Library: Material Web Components (MWC)
 
-The color palette is defined in `frontend/src/theme.js`.
+The application has transitioned from Material UI (MUI) to Material Web Components (@material/web) to align with the latest Material Design standards directly from Google.
 
-### Primary Colors
-*   **Primary Main (`primary.main`):** `#5C6AC4` (Used for primary actions, selected states, highlights)
-*   **Primary Contrast Text (`primary.contrastText`):** `#FFFFFF` (Text/icons on primary color backgrounds)
+MWC are integrated into the React application using the `@lit/react` library, which provides a `createComponent` function to wrap MWC elements for idiomatic React usage. These wrapped components are typically stored in `frontend/src/mwc_wrappers/`.
 
-### Secondary Colors
-*   **Secondary Main (`secondary.main`):** `#2C6ECB` (Used for secondary actions or alternative highlights)
-    * _Note: This was pre-existing and can be further evaluated for its role in the new Shopify-like theme._
+## 2. Theming with CSS Custom Properties
 
-### Semantic Colors
-*   **Success (`success.main`):** `#36A269`
-*   **Warning (`warning.main`):** `#EEC200`
-*   **Error (`error.main`):** `#D82C0D`
+Theming is now centralized in `frontend/src/mwc_theme.css`. This file defines Material Design tokens (for color, typography, shape, etc.) using CSS Custom Properties. These tokens are based on the Material Design 3 system.
 
-### Background Colors
-*   **Default Page Background (`background.default`):** `#F4F6F8` (Used for the main background of pages)
-*   **Paper Background (`background.paper`):** `#FFFFFF` (Used for cards, drawers, dialogs, etc.)
-*   **Header Background (`background.header`):** `#FFFFFF` (Specifically for the main AppBar)
-*   **Sidebar Background (`background.sidebar`):** `#FFFFFF` (Specifically for the navigation Drawer)
+MWC elements are designed to consume these CSS Custom Properties automatically. Global styles and component-specific overrides can also leverage these tokens.
 
-### Text Colors
-*   **Primary Text (`text.primary`):** `#1A1B1C` (Default text color)
-*   **Secondary Text (`text.secondary`):** `#6D7175` (For less important text, hints)
-*   **Disabled Text (`text.disabled`):** `#B4B7BA`
-*   **Placeholder Text (`text.placeholder`):** `#979797`
+### Key Theming Files:
+*   **`frontend/src/mwc_theme.css`**: Contains all global CSS Custom Property definitions for MWC theming. This is where you define your application's visual identity.
+*   **`frontend/src/index.js`**: Imports `mwc_theme.css` to apply the theme globally.
 
-### Action Colors
-*   **Hover (`action.hover`):** `#4755A9` (Hover state for primary elements)
+## 3. Core Theme Tokens (Defined in `mwc_theme.css`)
 
-### Other
-*   **Divider (`divider`):** `#E0E0E0` (For borders, dividers)
+Refer to `frontend/src/mwc_theme.css` for the complete list of tokens. Below is a conceptual overview:
 
-## 2. Typography
+### a. Color Palette
+Colors are defined using MWC's system color tokens (e.g., `--md-sys-color-primary`, `--md-sys-color-on-surface`, `--md-sys-color-error-container`). The palette in `mwc_theme.css` has been translated from the previous MUI theme and includes:
+*   Primary, Secondary, Tertiary palettes
+*   Error palette
+*   Neutral background and surface colors (including various container shades for elevation)
+*   Outline colors
+*   Specific "on-" colors for accessible text/icons on colored backgrounds.
 
-Typography is managed via the `typography` object in `frontend/src/theme.js`.
+### b. Typography
+Typography is managed via MWC's system typescale tokens (e.g., `--md-sys-typescale-body-large-font-family`, `--md-sys-typescale-headline-small-font-size`).
+*   **Font Family**: Defined by tokens like `--md-sys-typescale-font-family-brand` and `--md-sys-typescale-font-family-plain`. Currently set to 'Inter' and system fallbacks.
+*   **Typescale**: A comprehensive set of predefined roles (body, label, title, headline, display) with corresponding font sizes, weights, and line heights are available. The base body font size is typically `body-large` (14px).
 
-*   **Font Family (`fontFamily`):** `Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif`
-*   **Base Font Size (`fontSize`):** `14px` (Applied by MUI to the root)
+### c. Shape
+Shape characteristics, primarily corner radius, are defined using MWC's shape tokens (e.g., `--md-sys-shape-corner-medium`).
+*   A range of corner sizes are available (extra-small, small, medium, large, etc.).
+*   The `--md-sys-shape-corner-medium` token has been set to `10px` in `mwc_theme.css` to align with the previous application-wide border radius. MWC components will use these tokens for their border radiuses.
 
-### Key Type Styles:
-*   **h1 (`variant="h1"`):** `1.5rem` (24px), `fontWeight: 600`
-*   **h2 (`variant="h2"`):** `1.25rem` (20px), `fontWeight: 600`
-*   **h4 (used for Page Titles):** `1.5rem` (effectively `h1` size, as seen in `Page.js` and `App.js`) - _Consider aliasing page titles to `h1` in theme or component for semantic correctness if `h4` is not intentional._
-*   **subtitle1 (`variant="subtitle1"`):** `1rem` (16px), `fontWeight: 600`
-*   **subtitle2 (`variant="subtitle2"`):** `0.875rem` (14px), `fontWeight: 600`
-*   **body1 (`variant="body1"`):** `0.875rem` (14px), `fontWeight: 400`
-*   **body2 (`variant="body2"`):** `0.875rem` (14px)
-*   **Button Text (`MuiButton`):** `fontWeight: 600`, `textTransform: 'none'`
+## 4. Component Usage
 
-### Line Height
-*   A global line height of `1.5` is set on the `body` element in `frontend/src/index.css` for general text readability.
+*   **Prefer Wrapped MWC Components:** When building UI, prioritize using the React-wrapped MWC components from `frontend/src/mwc_wrappers/` or creating new wrappers for MWC elements as needed.
+*   **Styling:**
+    *   Leverage the global CSS Custom Properties from `mwc_theme.css` for styling.
+    *   MWC components often expose their own CSS Custom Properties for more granular styling. Refer to the individual MWC component documentation for these.
+    *   Avoid inline styles or one-off CSS classes where a theme token or component-specific token can achieve the same result.
 
-## 3. Spacing
+## 5. Atomicity & Reusability
 
-*   The theme uses `spacing: 4`. This means `theme.spacing(1)` equals `4px`. Common practice is to use multiples of this unit (e.g., `theme.spacing(2)` for `8px`, `theme.spacing(4)` for `16px`).
-*   Standard padding for `AppCard` components is `theme.spacing(2.5)` (i.e., `10px`, though this was `p:2.5` which might be `2.5 * 4px = 10px` if `theme.spacing` is not used directly there, or `2.5 * default 8px spacing = 20px` if it's a direct multiplier. The `AppCard` uses `p: 2.5` which means `2.5 * theme.spacing unit`. Since spacing unit is 4, this is 10px. This should be clarified or standardized, e.g. `p: theme.spacing(2.5)` is not valid, it should be `p: 2.5` with the expectation of the spacing unit, or `padding: theme.spacing(2.5)` if it's a style override).
-    *   _Clarification: `AppCard.js` uses `p: 2.5`. With `theme.spacing: 4`, this means `2.5 * 4px = 10px`. This is a bit unusual. Standard MUI practice is `theme.spacing(integer)`. Let's assume it means `10px` for now. The theme's `MuiPaper` has `p:2` which is `8px` by default._
-    *   **Update for AppCard**: The `AppCard` component itself has `p: 2.5`. This directly uses the theme's spacing unit. If `theme.spacing` is `4` (as it is), then `p:2.5` means `2.5 * 4px = 10px`. This should be noted as a specific padding for AppCards. General MUI components will use `theme.spacing(X)`.
+The frontend should continue to follow an atomic design structure (`atoms`, `molecules`, `organisms`, `templates`, `pages`) where possible, but now constructing these elements from wrapped MWC components.
 
-## 4. Border Radius
-
-*   **Global Border Radius (`shape.borderRadius`):** `10px`.
-*   This is applied to components like `Paper` (used by `AppCard`), `Button`, `TextField` (inputs), etc., through theme overrides.
-
-## 5. Shadows
-
-Subtle shadows are used to create depth and hierarchy, defined in `theme.shadows`.
-
-*   **`shadows[0]`:** `none`
-*   **`shadows[1]` (Default for `AppCard`, `AppBar`):** `'0px 1px 3px 0px rgba(0,0,0,0.07), 0px 1px 2px 0px rgba(0,0,0,0.03)'`
-*   **`shadows[2]`:** `'0px 2px 5px 0px rgba(0,0,0,0.07), 0px 1px 4px 0px rgba(0,0,0,0.04)'`
-*   **`shadows[3]` (Used for `DashboardCard` hover):** `'0px 4px 8px 0px rgba(0,0,0,0.07), 0px 2px 6px 0px rgba(0,0,0,0.05)'` (Example, actual value from theme array)
-*   Higher elevation shadows are available in the `theme.shadows` array for elements needing more prominence.
-
-## 6. Atomicity & Reusability
-
-*   The frontend follows an atomic design structure (`atoms`, `molecules`, `organisms`, `templates`, `pages`).
-*   **Atoms:** Basic building blocks (e.g., `AppCard`, `PrimaryButton`, `TextInput`). These should encapsulate base MUI components with any project-specific styling variations.
-*   **Molecules:** Groups of atoms forming simple components (e.g., `SearchBar`, `DropdownMenu`).
+*   **Atoms:** Basic building blocks (e.g., a wrapped MWC button, a wrapped MWC card). These should encapsulate the MWC element and its React wrapper, exposing necessary props and events.
+*   **Molecules:** Groups of atoms forming simple components.
 *   **Organisms:** More complex UI components composed of molecules and/or atoms.
-*   Strive to use and extend these reusable components rather than applying one-off styles. Modifications to the look and feel should primarily happen in `theme.js` or within these atomic components.
 
-This document should be updated as the design system evolves.
+Strive to use and extend these reusable components. Modifications to the look and feel should primarily happen in `mwc_theme.css` or by adjusting how MWC components are used and styled within the reusable React components.
+
+This document should be updated as the design system and MWC integration evolve.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/frontend/src/atoms/AppCard.js
+++ b/frontend/src/atoms/AppCard.js
@@ -1,40 +1,57 @@
-import React, { useRef, useEffect } from 'react';
-import '@material/web/labs/card/elevated-card.js';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MWCElevatedCard } from '../mwc_wrappers/MWCElevatedCard';
 
-const AppCard = ({ children, sx = {}, ...props }) => {
-  const cardRef = useRef(null);
+/**
+ * AppCard is a general purpose card component using MWCElevatedCard.
+ * It applies consistent padding and allows for additional styling.
+ */
+const AppCard = ({ children, sx = {}, style = {}, ...props }) => {
+  // Extract specific style properties that were handled by the inner div
+  // Default padding to 16px if not specified in sx.
+  const { p, padding: sxPadding, backgroundColor: sxBackgroundColor, ...otherSx } = sx;
 
-  // Extract padding and other styles from sx.
-  // Default padding to 16px (theme.spacing(4)) if not specified in sx.
-  const { p, padding = '16px', backgroundColor, ...otherSx } = sx;
+  // Determine final padding for the inner div
+  let finalPadding = '16px'; // Default
+  if (sxPadding) {
+    finalPadding = typeof sxPadding === 'number' ? `${sxPadding}px` : sxPadding;
+  }
+  if (p) { // p prop (theme spacing multiplier) overrides padding
+    finalPadding = `${p * 4}px`; // Assuming theme.spacing was 4
+  }
 
-  // If p is provided, it overrides padding. Assume p is a number like mui.
-  const finalPadding = p ? `${p * 4}px` : padding;
+  // Combine otherSx from sx prop and the direct style prop for the wrapper
+  const wrapperStyles = { ...otherSx, ...style };
 
-  useEffect(() => {
-    const cardElement = cardRef.current;
-    if (cardElement) {
-      // Apply any additional props to the web component
-      Object.entries(props).forEach(([key, value]) => {
-        if (key !== 'children' && key !== 'sx') {
-          cardElement.setAttribute(key, value);
-        }
-      });
-
-      // Apply other styles from sx to the card element
-      Object.entries(otherSx).forEach(([key, value]) => {
-        cardElement.style[key] = value;
-      });
-    }
-  }, [props, otherSx]);
+  // The MWCElevatedCard itself will receive other props directly.
+  // The sx prop is mostly deprecated in favor of direct `style` or CSS classes.
+  // We are preserving the inner div for padding and background color control,
+  // as this was the previous behavior.
 
   return (
-    <md-elevated-card ref={cardRef}>
-      <div style={{ padding: finalPadding, backgroundColor }}>
+    <MWCElevatedCard style={wrapperStyles} {...props}>
+      <div style={{ padding: finalPadding, backgroundColor: sxBackgroundColor }}>
         {children}
       </div>
-    </md-elevated-card>
+    </MWCElevatedCard>
   );
+};
+
+AppCard.propTypes = {
+  /**
+   * Content of the card.
+   */
+  children: PropTypes.node,
+  /**
+   * SX prop for MUI-like styling. Some properties (padding, backgroundColor)
+   * are applied to an inner div. Others are passed as `style` to the wrapper.
+   * Consider migrating to direct `style` prop or CSS classes.
+   */
+  sx: PropTypes.object,
+  /**
+   * Standard React style prop for the MWCElevatedCard wrapper.
+   */
+  style: PropTypes.object,
 };
 
 export default AppCard;

--- a/frontend/src/atoms/CheckboxInput.js
+++ b/frontend/src/atoms/CheckboxInput.js
@@ -1,34 +1,105 @@
-import React from 'react';
-import { MdCheckbox } from '@material/web/all.js';
+import React, { useId } from 'react';
+import PropTypes from 'prop-types';
+import { MWCCheckbox } from '../mwc_wrappers/MWCCheckbox';
 
-const CheckboxInput = ({ label, id, checked, onChange, disabled, sx = {}, ...props }) => {
-  const internalId = id || `checkbox-${React.useId()}`;
-  const { fontSize, ...otherSx } = sx; // Extract fontSize if needed for checkbox, apply rest to wrapper
+/**
+ * CheckboxInput provides a checkbox with a label, using MWCCheckbox.
+ */
+const CheckboxInput = ({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+  name,
+  value,
+  indeterminate = false,
+  required = false,
+  ...props
+}) => {
+  const autoId = useId(); // Generate a unique ID for associating label and checkbox
+  const checkboxId = props.id || autoId;
 
-  // MdCheckbox size can be controlled by --md-checkbox-icon-size
-  // The sx prop '& .MuiSvgIcon-root': { fontSize: 20 } would translate to setting this CSS var.
-  // For simplicity, we'll pass otherSx to the wrapper. Specific styling like icon size
-  // would ideally be part of a global theme for MWC or applied directly via style if critical.
-  const checkboxStyle = fontSize ? { '--md-checkbox-icon-size': fontSize } : {};
+  // The MWCCheckbox wrapper maps its 'change' event to the onChange prop.
+  // The native event.target for md-checkbox will have a 'checked' property.
+  const handleChange = (event) => {
+    if (onChange) {
+      // Construct a synthetic event or pass enough info for compatibility if needed.
+      // For MUI, onChange often received (event, checked).
+      // Here, event.target.checked is the new state.
+      onChange(event, event.target.checked);
+    }
+  };
 
+  // Make the entire component (div) clickable to toggle the checkbox
+  const handleContainerClick = () => {
+    if (!disabled) {
+      const checkboxElement = document.getElementById(checkboxId);
+      if (checkboxElement) {
+        checkboxElement.click();
+        // Clicking the checkbox programmatically will trigger its own 'change' event,
+        // which in turn calls our `handleChange` function.
+      }
+    }
+  };
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', ...otherSx }}>
-      <MdCheckbox
-        id={internalId}
-        checked={checked}
-        onChange={onChange} // Assumes onChange expects the event directly
+    <div
+      style={{
+        display: 'inline-flex', // Changed from flex to inline-flex for better layout flow with other elements
+        alignItems: 'center',
+        cursor: disabled ? 'default' : 'pointer',
+        // Add some margin to the component itself if it's a block, or let parent handle spacing
+        // margin: '8px 0'
+      }}
+      onClick={handleContainerClick}
+    >
+      <MWCCheckbox
+        id={checkboxId}
+        checked={checked} // Ensure this prop is correctly passed and controls the state
+        indeterminate={indeterminate}
+        onchange={handleChange} // MWC component's event is `onchange` (lowercase) if not using createComponent's event mapping
+                               // However, createComponent maps it to `onChange`, so this should be `onChange`
+        onChange={handleChange} // Correctly use the mapped event from createComponent
         disabled={disabled}
-        style={checkboxStyle}
-        {...props} // Pass other props like aria-labelledby
+        name={name}
+        value={value} // Pass value if it's used (e.g. in forms)
+        required={required}
+        // aria-labelledby={label ? `${checkboxId}-label` : undefined} // If label is separate and has an ID
+        {...props}
       />
       {label && (
-        <label htmlFor={internalId} style={{ marginLeft: '8px', cursor: disabled ? 'default' : 'pointer' }}>
+        <label
+          htmlFor={checkboxId} // Associates label with checkbox for accessibility and clickability
+          // id={`${checkboxId}-label`} // Not strictly needed if htmlFor is used correctly
+          style={{
+            marginLeft: '4px', // Adjust spacing as needed
+            cursor: disabled ? 'default' : 'pointer'
+          }}
+          // Prevent label click from triggering two events if div also clicks checkbox
+          onClick={(e) => e.stopPropagation()}
+        >
           {label}
         </label>
       )}
     </div>
   );
+};
+
+CheckboxInput.propTypes = {
+  label: PropTypes.string,
+  checked: PropTypes.bool,
+  /**
+   * Callback fired when the state changes.
+   * @param {object} event The event source of the callback.
+   * @param {boolean} checked The `checked` value of the checkbox.
+   */
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  value: PropTypes.any, // string, number, bool
+  indeterminate: PropTypes.bool,
+  required: PropTypes.bool,
+  id: PropTypes.string, // Allow passing an explicit id
 };
 
 export default CheckboxInput;

--- a/frontend/src/atoms/PrimaryButton.js
+++ b/frontend/src/atoms/PrimaryButton.js
@@ -1,37 +1,41 @@
-import React, { useRef, useEffect } from 'react';
-import '@material/web/button/filled-button.js'; // Importa el componente web directamente
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MWCFilledButton } from '../mwc_wrappers/MWCFilledButton';
 
-const PrimaryButton = ({ children, sx = {}, ...props }) => {
-  const buttonRef = useRef(null);
-
-  useEffect(() => {
-    const buttonElement = buttonRef.current;
-    if (buttonElement) {
-      // Aplica estilos y otras propiedades al componente web
-      Object.entries(props).forEach(([key, value]) => {
-        if (key !== 'children' && key !== 'sx') {
-          buttonElement.setAttribute(key, value);
-        }
-      });
-
-      // Aplica los estilos de 'sx' directamente al elemento DOM
-      const style = {
-        fontWeight: '600',
-        textTransform: 'none',
-        borderRadius: '10px',
-        ...sx,
-      };
-      Object.entries(style).forEach(([key, value]) => {
-        buttonElement.style[key] = value;
-      });
-    }
-  }, [props, sx]);
-
+/**
+ * PrimaryButton is a wrapper around the MWCFilledButton component.
+ * It's intended for primary actions.
+ */
+const PrimaryButton = ({ children, onClick, disabled = false, type = 'button', ...props }) => {
   return (
-    <md-filled-button ref={buttonRef}>
+    <MWCFilledButton
+      onClick={onClick}
+      disabled={disabled}
+      type={type} // Allow passing button type e.g. "submit"
+      {...props} // Spread any other props like 'aria-label', custom styles if necessary (though theme should handle most)
+    >
       {children}
-    </md-filled-button>
+    </MWCFilledButton>
   );
+};
+
+PrimaryButton.propTypes = {
+  /**
+   * The content of the button.
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Function to call when the button is clicked.
+   */
+  onClick: PropTypes.func,
+  /**
+   * If true, the button will be disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The type of the button (e.g., "button", "submit", "reset").
+   */
+  type: PropTypes.string,
 };
 
 export default PrimaryButton;

--- a/frontend/src/atoms/SecondaryButton.js
+++ b/frontend/src/atoms/SecondaryButton.js
@@ -1,48 +1,41 @@
 import React from 'react';
-import { MdOutlinedButton } from '@material/web/all.js';
+import PropTypes from 'prop-types';
+import { MWCOutlinedButton } from '../mwc_wrappers/MWCOutlinedButton';
 
-const SecondaryButton = ({ children, sx = {}, ...props }) => {
-  // Extract specific sx props and provide defaults from original component/guidelines
-  const {
-    borderRadius = '10px', // DESIGN_GUIDELINES.md global border radius (was 6 -> 24px or 6px?)
-    textTransform = 'none',
-    fontWeight = '600',
-    height = '36px',
-    px, // Specific padding from original sx
-    paddingLeft = px || '16px', // if px is '16px', this becomes '16pxpx' - needs fix
-    paddingRight = px || '16px', // if px is '16px', this becomes '16pxpx' - needs fix
-    ...otherSx // Capture any other sx properties
-  } = sx;
-
-  // Correctly handle px shorthand for padding
-  let finalPaddingLeft = paddingLeft;
-  let finalPaddingRight = paddingRight;
-
-  if (px && typeof px === 'string' && !px.endsWith('px') && !isNaN(parseFloat(px))) {
-    finalPaddingLeft = `${px}px`; // Assuming px was a number or string number
-    finalPaddingRight = `${px}px`;
-  } else if (px && typeof px === 'string') {
-    finalPaddingLeft = px; // px is already a string like '16px'
-    finalPaddingRight = px;
-  }
-
-
-  const style = {
-    fontWeight,
-    textTransform,
-    borderRadius,
-    height,
-    paddingLeft: finalPaddingLeft,
-    paddingRight: finalPaddingRight,
-    // Spread otherSx from props, allowing overrides
-    ...otherSx,
-  };
-
+/**
+ * SecondaryButton is a wrapper around the MWCOutlinedButton component.
+ * It's intended for secondary actions that need less emphasis than primary actions.
+ */
+const SecondaryButton = ({ children, onClick, disabled = false, type = 'button', ...props }) => {
   return (
-    <MdOutlinedButton style={style} {...props}>
+    <MWCOutlinedButton
+      onClick={onClick}
+      disabled={disabled}
+      type={type}
+      {...props}
+    >
       {children}
-    </MdOutlinedButton>
+    </MWCOutlinedButton>
   );
+};
+
+SecondaryButton.propTypes = {
+  /**
+   * The content of the button.
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Function to call when the button is clicked.
+   */
+  onClick: PropTypes.func,
+  /**
+   * If true, the button will be disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The type of the button (e.g., "button", "submit", "reset").
+   */
+  type: PropTypes.string,
 };
 
 export default SecondaryButton;

--- a/frontend/src/atoms/SwitchInput.js
+++ b/frontend/src/atoms/SwitchInput.js
@@ -1,43 +1,115 @@
-import React from 'react';
-import { MdSwitch } from '@material/web/all.js';
+import React, { useId } from 'react';
+import PropTypes from 'prop-types';
+import { MWCSwitch } from '../mwc_wrappers/MWCSwitch';
 
-const SwitchInput = ({ label, id, checked, onChange, disabled, sx = {}, ...props }) => {
-  const internalId = id || `switch-${React.useId()}`;
-  // sx properties like padding and boxShadow on thumb are not directly translatable
-  // to MdSwitch in the same way. MdSwitch has its own visual language.
-  // We pass the sx to the outer div for general layout styling.
-  // Specific MdSwitch theming would be done via CSS custom properties at a global level.
+/**
+ * SwitchInput provides a switch toggle with a label, using MWCSwitch.
+ */
+const SwitchInput = ({
+  label,
+  checked, // MUI uses 'checked', MWC Switch uses 'selected'
+  onChange,
+  disabled = false,
+  name,
+  value, // MWC Switch has a 'value' attribute
+  required = false,
+  showOnlySelectedIcon = false, // MWC specific: if true, shows icon only when selected
+  icons = false, // MWC specific: if true, shows default on/off icons
+  ...props
+}) => {
+  const autoId = useId();
+  const switchId = props.id || autoId;
 
+  // The MWCSwitch wrapper maps its 'change' event to the onChange prop.
+  // The native event.target for md-switch will have a 'selected' property.
   const handleChange = (event) => {
     if (onChange) {
-      // Adapt MdSwitch event (event.target.selected) to what a typical React onChange might expect (event.target.checked)
-      // However, it's often better to stick to the web component's event structure if possible.
-      // For this migration, let's assume the calling code expects an object with target.checked.
-      // If the original onChange expected the raw event or just the boolean, this needs adjustment.
-      const syntheticEvent = {
-        ...event,
-        target: { ...event.target, checked: event.target.selected },
-      };
-      onChange(syntheticEvent);
+      // MUI Switch onChange usually passes (event, checked_boolean)
+      // MWC Switch event.target.selected is the new state.
+      onChange(event, event.target.selected);
     }
   };
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', ...sx }}>
-      <MdSwitch
-        id={internalId}
-        selected={checked} // MdSwitch uses 'selected' instead of 'checked'
-        onInput={handleChange} // MdSwitch often uses 'input' or 'change'. 'input' is common for immediate value changes.
+    <div
+      style={{
+        display: 'inline-flex', // Use inline-flex for better flow with other elements
+        alignItems: 'center',
+        cursor: disabled ? 'default' : 'pointer',
+        // Adding some gap between switch and label if label exists
+        gap: label ? '8px' : '0px',
+      }}
+      // Allow clicking the div to toggle the switch, mainly for the label area
+      onClick={(e) => {
+        // Prevent click if it's on the switch itself to avoid double toggle
+        // or if the click is on any interactive element within the div already.
+        if (!disabled && e.target === e.currentTarget) { // Only if the click is directly on the div
+          const switchElement = document.getElementById(switchId);
+          switchElement?.click(); // Programmatic click triggers the switch's own event handling
+        }
+      }}
+    >
+      <MWCSwitch
+        id={switchId}
+        selected={checked} // Map 'checked' to 'selected'
+        onChange={handleChange} // The wrapper ensures this is the correct prop name for the 'change' event
         disabled={disabled}
-        {...props} // Pass other props
+        name={name}
+        value={value} // Pass value if used (e.g. in forms)
+        required={required} // Pass required if used
+        icons={icons} // MWC specific prop
+        showOnlySelectedIcon={showOnlySelectedIcon} // MWC specific prop
+        {...props} // Pass other MWC specific props
       />
       {label && (
-        <label htmlFor={internalId} style={{ marginLeft: '8px', cursor: disabled ? 'default' : 'pointer' }}>
+        <label
+          htmlFor={switchId} // Associates label with switch
+          style={{
+            cursor: disabled ? 'default' : 'pointer',
+            // Prevent text selection on double click if desired
+            userSelect: 'none',
+          }}
+          // The div's onClick handles toggling when clicking the label area.
+          // No separate onClick needed on label itself if it's part of the clickable div.
+          // If label click needs to be handled separately (e.g. to prevent div's action),
+          // then add onClick={(e) => e.stopPropagation()} here.
+          // For simplicity, letting the div's click handler manage it.
+        >
           {label}
         </label>
       )}
     </div>
   );
+};
+
+SwitchInput.propTypes = {
+  label: PropTypes.string,
+  /**
+   * If true, the switch is checked (selected).
+   */
+  checked: PropTypes.bool,
+  /**
+   * Callback fired when the state changes.
+   * @param {object} event The event source of the callback.
+   * @param {boolean} selected The `selected` (checked) value of the switch.
+   */
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  /**
+   * The value of the component.
+   */
+  value: PropTypes.string,
+  required: PropTypes.bool,
+  id: PropTypes.string,
+  /**
+   * MWC Specific: Shows the icon only when selected.
+   */
+  showOnlySelectedIcon: PropTypes.bool,
+  /**
+   * MWC Specific: Shows the default on/off icons.
+   */
+  icons: PropTypes.bool,
 };
 
 export default SwitchInput;

--- a/frontend/src/atoms/TextInput.js
+++ b/frontend/src/atoms/TextInput.js
@@ -1,26 +1,108 @@
-import React, { useRef, useEffect } from 'react';
-import '@material/web/textfield/outlined-text-field.js';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MWCOutlinedTextField } from '../mwc_wrappers/MWCOutlinedTextField';
 
-const TextInput = ({ label, value, onChange, ...props }) => {
-  const ref = useRef(null);
+/**
+ * TextInput is a wrapper around the MWCOutlinedTextField component,
+ * providing a standardized text input field.
+ */
+const TextInput = ({
+  label,
+  value,
+  onChange,
+  onInput, // Allow passing onInput for more immediate feedback if needed
+  disabled = false,
+  placeholder,
+  type = 'text',
+  name,
+  error = false,
+  helperText, // This will be mapped to supporting-text or error-text
+  required = false,
+  readOnly = false,
+  // MWC specific attributes might be useful:
+  // icon, iconTrailing, prefixText, suffixText,
+  // minLength, maxLength, pattern, min, max, step
+  ...props // For any other MWC text-field specific attributes
+}) => {
 
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.addEventListener('input', (e) => {
-        onChange(e.target.value);
-      });
+  // MWC text fields use event.target.value for changes.
+  // The MWCOutlinedTextField wrapper maps MWC's 'input' event to its `onInput` prop,
+  // and MWC's 'change' event to its `onChange` prop.
+
+  // For this TextInput component, we want `onChange` to be the primary way to handle value updates
+  // for controlled component behavior, similar to how MUI's TextField `onChange` works (fires on every value change).
+  // MWC's `input` event is the one that fires on every value change.
+  // MWC's `change` event typically fires on blur or Enter.
+
+  // So, we map this component's `onChange` prop to the wrapper's `onInput` prop.
+  // If the user also provides an `onInput` prop to this TextInput, it will also be called.
+  const handleInput = (event) => {
+    if (onChange) {
+      onChange(event); // Call the user's onChange for controlled behavior
     }
-  }, [onChange]);
+    if (onInput) {
+      onInput(event); // Call the user's onInput if they provided one
+    }
+  };
 
   return (
-    <md-outlined-text-field
-      ref={ref}
+    <MWCOutlinedTextField
       label={label}
-      value={value}
-      {...props}
+      value={value || ''} // MWC fields often need a defined value, ensure it's not null/undefined
+      type={type}
+      name={name}
+      placeholder={placeholder}
+      disabled={disabled}
+      required={required}
+      readOnly={readOnly} // maps to readonly attribute
+      error={error} // MWC uses this boolean attribute for error state
+      supportingText={!error && helperText ? helperText : undefined}
+      errorText={error && helperText ? helperText : undefined} // MWC specific for error message
+
+      // Event handling:
+      // Connect our combined handler to the wrapper's onInput (which is MWC 'input' event)
+      onInput={handleInput}
+      // If the user wants to specifically listen to MWC's 'change' event (on blur/enter),
+      // they can pass it as props.onChange directly to MWCOutlinedTextField via {...props}
+      // However, our wrapper already maps 'change' to 'onChange'.
+      // To avoid confusion, we explicitly don't pass this.props.onChange if it's the same as our main onChange.
+      // If they pass a different onChange in ...props, it might override or cause issues.
+      // For clarity, it's better if this component defines what its props do.
+      // The MWCOutlinedTextField wrapper has `onChange` for the 'change' event.
+      // We will not use it here to avoid confusion with this component's `onChange` for controlled input.
+      {...props} // Pass other MWC-specific props
     >
-    </md-outlined-text-field>
+      {/* Example of how icons could be passed if this component supported them: */}
+      {/* {leadingIcon && <MWCIcon slot="leading-icon">{leadingIcon}</MWCIcon>} */}
+      {/* {trailingIcon && <MWCIcon slot="trailing-icon">{trailingIcon}</MWCIcon>} */}
+    </MWCOutlinedTextField>
   );
+};
+
+TextInput.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Function to call when the input value changes (on each keystroke).
+   * Receives the event; access value via event.target.value.
+   * This is mapped to the 'input' event of the MWC text field.
+   */
+  onChange: PropTypes.func,
+  /**
+   * Optional: Also fires on each keystroke, same as onChange.
+   * Can be used if a separate handler for 'input' is needed alongside `onChange`.
+   */
+  onInput: PropTypes.func,
+  disabled: PropTypes.bool,
+  placeholder: PropTypes.string,
+  type: PropTypes.string,
+  name: PropTypes.string,
+  error: PropTypes.bool,
+  helperText: PropTypes.string,
+  required: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  // leadingIcon: PropTypes.string, // Example if we added icon support
+  // trailingIcon: PropTypes.string, // Example if we added icon support
 };
 
 export default TextInput;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import './mwc_theme.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/frontend/src/molecules/MaterialCard.js
+++ b/frontend/src/molecules/MaterialCard.js
@@ -1,42 +1,37 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import '@material/web/labs/card/elevated-card.js';
-import '@material/web/button/filled-button.js';
+import { MWCElevatedCard } from '../mwc_wrappers/MWCElevatedCard'; // Adjusted import path
+import { MWCFilledButton } from '../mwc_wrappers/MWCFilledButton';   // Adjusted import path
 
-const MaterialCard = ({ title, content, actionText, onActionClick }) => {
-  const cardRef = useRef(null);
-  const buttonRef = useRef(null);
+// Note: The direct MWC imports like '@material/web/labs/card/elevated-card.js'
+// are no longer needed here as they are handled by the wrapper components.
 
-  useEffect(() => {
-    const buttonElement = buttonRef.current;
-    if (buttonElement && onActionClick) {
-      buttonElement.addEventListener('click', onActionClick);
-      return () => {
-        buttonElement.removeEventListener('click', onActionClick);
-      };
-    }
-  }, [onActionClick]);
+const MaterialCard = ({ title, content, actionText, onActionClick, children }) => {
+  // Removed useRef and useEffect for manual event listeners.
+  // Event handling is now done via props on the wrapped components.
 
   return (
-    <md-elevated-card ref={cardRef}>
-      <div style={{ padding: '16px' }}>
-        <h3>{title}</h3>
-        <p>{content}</p>
+    <MWCElevatedCard>
+      <div style={{ padding: '16px' }}> {/* Existing padding, can be reviewed later if MWC card has built-in padding options */}
+        {title && <h3>{title}</h3>}
+        {content && <p>{content}</p>}
+        {children} {/* Allow children to be passed through */}
         {actionText && onActionClick && (
-          <div style={{ marginTop: '16px', textAlign: 'right' }}>
-            <md-filled-button ref={buttonRef}>
+          <div style={{ marginTop: '16px', textAlign: 'right' }}> {/* Existing layout styling */}
+            <MWCFilledButton onClick={onActionClick}>
               {actionText}
-            </md-filled-button>
+            </MWCFilledButton>
           </div>
         )}
       </div>
-    </md-elevated-card>
+    </MWCElevatedCard>
   );
 };
 
 MaterialCard.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
+  title: PropTypes.string, // No longer required, can be optional
+  content: PropTypes.string, // No longer required, can be optional
+  children: PropTypes.node, // Added to allow more flexible content
   actionText: PropTypes.string,
   onActionClick: PropTypes.func,
 };

--- a/frontend/src/mwc_theme.css
+++ b/frontend/src/mwc_theme.css
@@ -1,0 +1,182 @@
+/*
+  Material Web Components Global Theme
+  Translated from frontend/src/theme.js (MUI theme)
+*/
+
+:root {
+  /* --- Color System Tokens (Based on Material Design 3) --- */
+  /* Using names from https://m3.material.io/styles/color/system-tokens */
+
+  /* Primary Palette */
+  --md-sys-color-primary: #5C6AC4; /* from primary.main */
+  --md-sys-color-on-primary: #FFFFFF; /* from primary.contrastText */
+  --md-sys-color-primary-container: #E0E0FF; /* Approximate, lighter shade of primary */
+  --md-sys-color-on-primary-container: #101070; /* Approximate, darker for contrast */
+
+  /* Secondary Palette (MWC often uses 'secondary' for less emphasis than primary) */
+  --md-sys-color-secondary: #545F7D; /* Derived from primary, less saturated, or could be a new accent */
+  --md-sys-color-on-secondary: #FFFFFF;
+  --md-sys-color-secondary-container: #DDE2FF; /* Approximate */
+  --md-sys-color-on-secondary-container: #101A37; /* Approximate */
+
+  /* Tertiary Palette (Can be used for extra accents, mapped from MUI secondary.main for now) */
+  --md-sys-color-tertiary: #2C6ECB; /* from secondary.main */
+  --md-sys-color-on-tertiary: #FFFFFF;
+  --md-sys-color-tertiary-container: #DCEBFF; /* Approximate */
+  --md-sys-color-on-tertiary-container: #001D36; /* Approximate */
+
+  /* Error Palette */
+  --md-sys-color-error: #D82C0D; /* from error.main */
+  --md-sys-color-on-error: #FFFFFF;
+  --md-sys-color-error-container: #FFDAD4; /* Approximate */
+  --md-sys-color-on-error-container: #410001; /* Approximate */
+
+  /* Neutral Palette (Backgrounds & Surfaces) */
+  --md-sys-color-background: #F4F6F8; /* from background.default */
+  --md-sys-color-on-background: #1A1B1C; /* from text.primary */
+
+  --md-sys-color-surface: #FFFFFF; /* from background.paper - for cards, dialogs etc. */
+  --md-sys-color-on-surface: #1A1B1C; /* from text.primary */
+  --md-sys-color-surface-variant: #E7E0EC; /* Neutral variant for different surfaces */
+  --md-sys-color-on-surface-variant: #49454F; /* For text on surface-variant, similar to text.secondary */
+
+  /* Surface Container Colors (new in M3 for elevation/emphasis) */
+  --md-sys-color-surface-container-lowest: #FFFFFF; /* Was background.paper */
+  --md-sys-color-surface-container-low: #FDF8FD;    /* Slightly off-white */
+  --md-sys-color-surface-container: #F7F2F7;      /* Default container */
+  --md-sys-color-surface-container-high: #F2ECF2;   /* Higher emphasis */
+  --md-sys-color-surface-container-highest: #EDE7ED; /* Highest emphasis */
+
+  /* Outline */
+  --md-sys-color-outline: #808080; /* General outline, similar to MUI divider but might need adjustment */
+  --md-sys-color-outline-variant: #C4C4C4; /* from MUI textfield fieldset border */
+
+  /* Inverse (for dark text on light primary, etc. - not commonly needed if on-primary is white) */
+  /* --md-sys-color-inverse-primary: ... */
+  /* --md-sys-color-inverse-surface: ... */
+  /* --md-sys-color-inverse-on-surface: ... */
+
+  /* Semantic colors from MUI (can be mapped to custom properties if needed, or use MWC defaults) */
+  --custom-color-success: #36A269;
+  --custom-color-warning: #EEC200;
+
+
+  /* --- Typography System Tokens (Based on Material Design 3) --- */
+  /* Using names from https://m3.material.io/styles/typography/tokens */
+  --md-sys-typescale-font-family-brand: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --md-sys-typescale-font-family-plain: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+
+  --md-sys-typescale-body-small-font-family: var(--md-sys-typescale-font-family-plain);
+  --md-sys-typescale-body-small-font-weight: 400;
+  --md-sys-typescale-body-small-font-size: 0.75rem; /* 12px */
+  --md-sys-typescale-body-small-line-height: 1.33;
+
+  --md-sys-typescale-body-medium-font-family: var(--md-sys-typescale-font-family-plain);
+  --md-sys-typescale-body-medium-font-weight: 400;
+  --md-sys-typescale-body-medium-font-size: 0.875rem; /* 14px - MUI base fontSize */
+  --md-sys-typescale-body-medium-line-height: 1.43;
+
+  --md-sys-typescale-body-large-font-family: var(--md-sys-typescale-font-family-plain);
+  --md-sys-typescale-body-large-font-weight: 400; /* MUI body1 */
+  --md-sys-typescale-body-large-font-size: 0.875rem; /* MUI body1 (14px) */
+  --md-sys-typescale-body-large-line-height: 1.43;
+
+  --md-sys-typescale-label-small-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-label-small-font-weight: 500;
+  --md-sys-typescale-label-small-font-size: 0.6875rem; /* 11px */
+  --md-sys-typescale-label-small-line-height: 1.45;
+
+  --md-sys-typescale-label-medium-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-label-medium-font-weight: 500;
+  --md-sys-typescale-label-medium-font-size: 0.75rem; /* 12px */
+  --md-sys-typescale-label-medium-line-height: 1.33;
+
+  --md-sys-typescale-label-large-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-label-large-font-weight: 500;
+  --md-sys-typescale-label-large-font-size: 0.875rem; /* 14px */
+  --md-sys-typescale-label-large-line-height: 1.43;
+
+  --md-sys-typescale-title-small-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-title-small-font-weight: 500;
+  --md-sys-typescale-title-small-font-size: 0.875rem; /* 14px */
+  --md-sys-typescale-title-small-line-height: 1.43;
+
+  --md-sys-typescale-title-medium-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-title-medium-font-weight: 600; /* MUI h4 */
+  --md-sys-typescale-title-medium-font-size: 1rem; /* MUI h4 (16px) */
+  --md-sys-typescale-title-medium-line-height: 1.5;
+
+  --md-sys-typescale-title-large-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-title-large-font-weight: 600; /* MUI h3 */
+  --md-sys-typescale-title-large-font-size: 1.125rem; /* MUI h3 (18px) */
+  --md-sys-typescale-title-large-line-height: 1.55;
+
+  --md-sys-typescale-headline-small-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-headline-small-font-weight: 600; /* MUI h2 */
+  --md-sys-typescale-headline-small-font-size: 1.25rem; /* MUI h2 (20px) */
+  --md-sys-typescale-headline-small-line-height: 1.6;
+
+  --md-sys-typescale-headline-medium-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-headline-medium-font-weight: 600;
+  --md-sys-typescale-headline-medium-font-size: 1.5rem; /* 24px */
+  --md-sys-typescale-headline-medium-line-height: 1.5;
+
+  --md-sys-typescale-headline-large-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-headline-large-font-weight: 600;
+  --md-sys-typescale-headline-large-font-size: 1.75rem; /* 28px */
+  --md-sys-typescale-headline-large-line-height: 1.43;
+
+  --md-sys-typescale-display-small-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-display-small-font-weight: 600; /* MUI h1 */
+  --md-sys-typescale-display-small-font-size: 1.75rem; /* MUI h1 (28px) - MWC display small is usually larger, adjust if needed */
+  --md-sys-typescale-display-small-line-height: 1.43;
+
+  --md-sys-typescale-display-medium-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-display-medium-font-weight: 600;
+  --md-sys-typescale-display-medium-font-size: 2.8125rem; /* 45px */
+  --md-sys-typescale-display-medium-line-height: 1.15;
+
+  --md-sys-typescale-display-large-font-family: var(--md-sys-typescale-font-family-brand);
+  --md-sys-typescale-display-large-font-weight: 600;
+  --md-sys-typescale-display-large-font-size: 3.5625rem; /* 57px */
+  --md-sys-typescale-display-large-line-height: 1.12;
+
+  /* --- Shape System Tokens --- */
+  /* General shape tokens for corners */
+  --md-sys-shape-corner-none: 0px;
+  --md-sys-shape-corner-extra-small: 4px;
+  --md-sys-shape-corner-small: 8px;
+  --md-sys-shape-corner-medium: 12px; /* Default for many components */
+  --md-sys-shape-corner-large: 16px;
+  --md-sys-shape-corner-extra-large: 28px;
+  --md-sys-shape-corner-full: 9999px; /* For pills, circular elements */
+
+  /* Applying your specific borderRadius (10px) to a custom category if needed, or adjust medium. */
+  /* For now, we'll use MWC's standard scale. 10px is between small (8px) and medium (12px) */
+  /* We can override component-specific tokens later if 10px is strictly needed everywhere. */
+  /* Example: --md-ref-shape-corner-medium: 10px; if you want to change the default medium */
+   --md-sys-shape-corner-medium: 10px; /* Overriding MWC medium to match MUI borderRadius */
+
+
+  /* --- Default body styles --- */
+  body {
+    font-family: var(--md-sys-typescale-body-large-font-family);
+    font-size: var(--md-sys-typescale-body-large-font-size);
+    line-height: var(--md-sys-typescale-body-large-line-height);
+    font-weight: var(--md-sys-typescale-body-large-font-weight);
+    background-color: var(--md-sys-color-background);
+    color: var(--md-sys-color-on-background);
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Apply some default styles to MWC components if necessary, */
+  /* though they should pick up these tokens automatically. */
+  /* Example for a button (actual MWC components might have their own token names to override) */
+  /*
+  md-filled-button {
+    --md-filled-button-container-shape: var(--md-sys-shape-corner-medium);
+    --md-filled-button-label-text-font: var(--md-sys-typescale-label-large-font-family);
+  }
+  */
+}

--- a/frontend/src/mwc_wrappers/MWCCheckbox.js
+++ b/frontend/src/mwc_wrappers/MWCCheckbox.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdCheckbox } from '@material/web/checkbox/checkbox.js';
+
+export const MWCCheckbox = createComponent({
+  tagName: 'md-checkbox',
+  elementClass: MdCheckbox,
+  react: React,
+  events: {
+    onChange: 'change', // MWC checkbox fires 'change' when its selected state changes
+    // 'input' might also be available, but 'change' is standard for selection changes.
+  },
+});

--- a/frontend/src/mwc_wrappers/MWCCircularProgress.js
+++ b/frontend/src/mwc_wrappers/MWCCircularProgress.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdCircularProgress } from '@material/web/progress/circular-progress.js';
+
+export const MWCCircularProgress = createComponent({
+  tagName: 'md-circular-progress',
+  elementClass: MdCircularProgress,
+  react: React,
+  events: {},
+});

--- a/frontend/src/mwc_wrappers/MWCElevatedCard.js
+++ b/frontend/src/mwc_wrappers/MWCElevatedCard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdElevatedCard } from '@material/web/labs/card/elevated-card.js'; // Path based on existing MaterialCard.js
+
+export const MWCElevatedCard = createComponent({
+  tagName: 'md-elevated-card',
+  elementClass: MdElevatedCard,
+  react: React,
+  events: {
+    // Add any specific events if needed, e.g. onCardClicked: 'click'
+    // For a generic card, direct click handling on the component instance might be sufficient
+  },
+});

--- a/frontend/src/mwc_wrappers/MWCFilledButton.js
+++ b/frontend/src/mwc_wrappers/MWCFilledButton.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdFilledButton } from '@material/web/button/filled-button.js'; // Path based on existing MaterialCard.js
+
+export const MWCFilledButton = createComponent({
+  tagName: 'md-filled-button',
+  elementClass: MdFilledButton,
+  react: React,
+  events: {
+    // Standard HTMLButtonElement events like 'click' are generally handled by React automatically
+    // if not specified here. However, for custom events fired by the component, you'd add them.
+    // For example, if it fired a 'custom-action', you might have: onCustomAction: 'custom-action'
+  },
+});

--- a/frontend/src/mwc_wrappers/MWCIcon.js
+++ b/frontend/src/mwc_wrappers/MWCIcon.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdIcon } from '@material/web/icon/icon.js';
+
+// It's crucial to ensure the Material Symbols font is loaded in the application.
+// This is typically done by adding the following in your main HTML file (e.g., public/index.html):
+// <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+// Or Material Symbols Rounded, Sharp, etc.
+
+export const MWCIcon = createComponent({
+  tagName: 'md-icon',
+  elementClass: MdIcon,
+  react: React,
+  events: {},
+});
+
+// Usage: <MWCIcon>icon_name</MWCIcon> or <MWCIcon icon="icon_name" /> if the component supports an icon attribute.
+// The standard way is <MWCIcon>settings</MWCIcon>
+// Children will be slotted as the icon name.

--- a/frontend/src/mwc_wrappers/MWCOutlinedButton.js
+++ b/frontend/src/mwc_wrappers/MWCOutlinedButton.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdOutlinedButton } from '@material/web/button/outlined-button.js';
+
+export const MWCOutlinedButton = createComponent({
+  tagName: 'md-outlined-button',
+  elementClass: MdOutlinedButton,
+  react: React,
+  events: {},
+});

--- a/frontend/src/mwc_wrappers/MWCOutlinedTextField.js
+++ b/frontend/src/mwc_wrappers/MWCOutlinedTextField.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdOutlinedTextField } from '@material/web/textfield/outlined-text-field.js';
+
+export const MWCOutlinedTextField = createComponent({
+  tagName: 'md-outlined-text-field',
+  elementClass: MdOutlinedTextField,
+  react: React,
+  events: {
+    onInput: 'input', // Standard input event
+    onChange: 'change', // Standard change event
+    // MWC text fields might use 'input' or 'change' for value updates.
+    // 'keydown', 'keyup', 'keypress' can also be mapped if needed.
+    // For controlled components, we might need to map specific events
+    // that fire when the value is committed by the user.
+    // The 'input' event is often used for real-time value changes.
+    // The 'change' event might fire on blur or when Enter is pressed.
+  },
+});

--- a/frontend/src/mwc_wrappers/MWCSwitch.js
+++ b/frontend/src/mwc_wrappers/MWCSwitch.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdSwitch } from '@material/web/switch/switch.js';
+
+export const MWCSwitch = createComponent({
+  tagName: 'md-switch',
+  elementClass: MdSwitch,
+  react: React,
+  events: {
+    // `md-switch` fires an `input` event when its state changes (selected or not)
+    // and also a `change` event.
+    // 'input' is often preferred for immediate feedback.
+    // 'change' might be after interaction finishes.
+    // Let's map `onChange` to the 'change' event, as it's a common name for selection changes.
+    // Or map to 'input' if that's more aligned with how it was used with MUI.
+    // The MdSwitch 'selected' property reflects its state. The event detail might also carry this.
+    // According to MWC docs, 'change' is the one to listen for user interaction changes.
+    onChange: 'change',
+  },
+});

--- a/frontend/src/mwc_wrappers/MWCTextButton.js
+++ b/frontend/src/mwc_wrappers/MWCTextButton.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createComponent } from '@lit/react';
+import { MdTextButton } from '@material/web/button/text-button.js';
+
+export const MWCTextButton = createComponent({
+  tagName: 'md-text-button',
+  elementClass: MdTextButton,
+  react: React,
+  events: {},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@lit/react": "^1.0.7",
+        "@material/web": "^2.3.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ=="
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
+      "integrity": "sha512-cencnwwLXQKiKxjfFzSgZRngcWJzUDZi/04E0fSaF86wZgchMdvTyu+lE36DrUfvuus3bH8+xLPrhM1cTjwpzw==",
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
+      "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "node_modules/@material/web": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-2.3.0.tgz",
+      "integrity": "sha512-r7ccZHthMk5tM05goPJ965hQ99ptMyZt7i8Xi8+RmEqK3ZXaMtjx+s4p+9OVX+vgOS3zpop+g1yGYXtOOlrwUg==",
+      "dependencies": {
+        "lit": "^2.8.0 || ^3.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
+      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
+    },
+    "node_modules/lit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
+      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
+      "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@lit/react": "^1.0.7",
+    "@material/web": "^2.3.0"
+  }
+}


### PR DESCRIPTION
This commit marks the first phase of migrating the frontend from Material UI (MUI) to Material Web Components (MWC).

Key changes include:

1.  **MWC Foundation & Theming:**
    *   Installed `@material/web` and `@lit/react` libraries.
    *   Created `frontend/src/mwc_theme.css`, populating it with CSS Custom Properties for colors, typography, and shape, translated from the existing MUI theme (`frontend/src/theme.js`). This establishes the base theme for MWC components.
    *   Imported `mwc_theme.css` globally in `frontend/src/index.js`.
    *   Updated `DESIGN_GUIDELINES.md` to reflect the new MWC-first strategy, theming approach, and component usage guidelines.

2.  **MWC Component Wrappers:**
    *   Created a new directory `frontend/src/mwc_wrappers/` for React components that wrap MWC elements using `@lit/react`'s `createComponent`.
    *   Implemented wrappers for several key MWC components:
        *   `MWCElevatedCard` (for `md-elevated-card`)
        *   `MWCFilledButton`, `MWCOutlinedButton`, `MWCTextButton` (for button variants)
        *   `MWCIcon` (for `md-icon`)
        *   `MWCCircularProgress` (for `md-circular-progress`)
        *   `MWCOutlinedTextField` (for `md-outlined-text-field`)
        *   `MWCCheckbox` (for `md-checkbox`)
        *   `MWCSwitch` (for `md-switch`)
    *   Added the Material Symbols font link to `frontend/public/index.html` to enable `MWCIcon` usage.

3.  **Refactored Components:**
    *   **Molecule:**
        *   `frontend/src/molecules/MaterialCard.js` was refactored to use `MWCElevatedCard` and `MWCFilledButton` wrappers, removing manual DOM manipulation.
    *   **Atoms (from `frontend/src/atoms/`):**
        *   `PrimaryButton.js` refactored to use `MWCFilledButton`.
        *   `SecondaryButton.js` refactored to use `MWCOutlinedButton`.
        *   `AppCard.js` refactored to use `MWCElevatedCard`, maintaining some compatibility for the `sx` prop for padding/background via an inner div.
        *   `TextInput.js` refactored to use `MWCOutlinedTextField`, mapping props like `label`, `value`, `error`, and `helperText` appropriately.
        *   `CheckboxInput.js` refactored to use `MWCCheckbox`, including manual label management with `useId` for accessibility and clickability.
        *   `SwitchInput.js` refactored to use `MWCSwitch`, mapping `checked` to `selected` and including manual label management with `useId`.

This work establishes the groundwork for the full MWC migration. The next steps involve refactoring the remaining atomic components, followed by molecules, organisms, layout, and pages, and then enhancing the overall UI/UX.