### PR TITLE
Fix: Correct Material UI tooltip import and React.useId call

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,30 @@
+# Node.js
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
+build
+dist
+
+# Docker specific
+Dockerfile
+.dockerignore
+
+# Version control
+.git
+.gitignore
+.hg
+.svn
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: Build the React application
+FROM node:18-alpine AS build-stage
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json (or yarn.lock if used)
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Stage 2: Serve the application with Nginx
+FROM nginx:stable-alpine
+
+# Copy built assets from the build stage
+COPY --from=build-stage /app/build /usr/share/nginx/html
+
+# Expose port 80 for Nginx
+EXPOSE 80
+
+# Nginx will automatically start and serve files from /usr/share/nginx/html
+# when the container starts.
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/atoms/AppTooltip.js
+++ b/frontend/src/atoms/AppTooltip.js
@@ -1,7 +1,8 @@
 import React, { useRef, useEffect } from 'react';
-import '@material/web/tooltip/tooltip.js';
+import '@material/web/tooltip/tooltip';
 
 const AppTooltip = ({ children, title, placement = 'bottom', ...props }) => {
+  const internalUniqueId = React.useId(); // Moved to the top
   const childRef = useRef(null);
   const tooltipRef = useRef(null);
 
@@ -55,7 +56,7 @@ const AppTooltip = ({ children, title, placement = 'bottom', ...props }) => {
   }
 
   // The id for associating tooltip with anchor
-  const anchorId = `tooltip-anchor-${React.useId()}`;
+  const anchorId = `tooltip-anchor-${internalUniqueId}`;
 
   return (
     <>


### PR DESCRIPTION
- I updated the import path for the Material Web tooltip in AppTooltip.js.
- I moved React.useId to the top level in AppTooltip.js to comply with hooks rules.

Feat: Dockerize frontend application

- I added a multi-stage Dockerfile to build the React frontend and serve it with Nginx.
- I created a .dockerignore file to optimize the Docker build context.
- I provided instructions for building and running the frontend Docker image.